### PR TITLE
YML with redone whitespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,12 @@ The master branch holds the most recent stable version of the code vetted by the
 All branches off your batch branch must be prefixed with your batch's numeric identifier (e.g. 1807). Stray branches will be deleted.
 
 The sledgehammer branch is the product owner's own branch, please do not use this one.
+
+##YML
+The convention for the YML files:
+- The document begins with the Spring declaration to begin with a uniform starting point, with no white space
+- All other main lines of the YML file begin with no white space 
+- From this intial main line, all following lines will get four additional white spaces
+- This process continues for as many additional lines as needed, with each getting an additional four white spaces
+- If any comments are added to the YML file then the # should be at the third white space
+- Any information for the comment should follow the line spacing listed above, so the # can be removed but the convention remains the same

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,13 @@
 spring:
-   application:
-      name: screenforce-discovery-server
+    application:
+        name: screenforce-discovery-server
 server:
-   port: 8761
+    port: 8761
 eureka:
     instance:
-      hostname: localhost
+        hostname: localhost
     client:
-      register-with-eureka: false
-      fetch-registry: false
+        register-with-eureka: false
+        fetch-registry: false
     server:
-       enable-self-preservation: false
+        enable-self-preservation: false


### PR DESCRIPTION
whitespacing structure I found to be the most clear and readable was as follows: every YML file begins with the Spring line, to make them all uniform; every main line starts without whitespace; then every additional line beneath the main line gets 4 whitespaces per line, this process continues for however many additional lines a given main line may need; if any comments are added to the document, the # begins at the 3rd whitespace, and the whitespace following the hashtag is as it should be if the # was not there (i.e. 4 white spaces for every line after the first)